### PR TITLE
Created a new context and provider for mail links

### DIFF
--- a/features/layout/sidebar-navigation/index.ts
+++ b/features/layout/sidebar-navigation/index.ts
@@ -1,2 +1,3 @@
 export { SidebarNavigation } from "./sidebar-navigation";
 export { NavigationContext, NavigationProvider } from "./navigation-context";
+export { MailLinkContext, MailLinkProvider } from "./mail-link-context";

--- a/features/layout/sidebar-navigation/mail-link-context.tsx
+++ b/features/layout/sidebar-navigation/mail-link-context.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type MailLinkContextProviderProps = {
+  openMailLink?: () => void;
+  children?: React.ReactNode;
+};
+
+const defaultContext = {
+  openMailLink: (
+    recipient: string = "support@prolog-app.com",
+    subject: string = "Support Request:",
+  ) => {
+    const mailToURL = encodeURI(`mailTo:${recipient}?subject=${subject}`);
+    window.open(mailToURL, "_blank");
+  },
+};
+
+export const MailLinkContext = React.createContext(defaultContext);
+
+export function MailLinkProvider({
+  openMailLink,
+  children,
+}: MailLinkContextProviderProps) {
+  return (
+    <MailLinkContext.Provider
+      value={{ openMailLink: openMailLink || defaultContext.openMailLink }}
+    >
+      {children}
+    </MailLinkContext.Provider>
+  );
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from "react";
 import { Routes } from "@config/routes";
 import classNames from "classnames";
 import { NavigationContext } from "./navigation-context";
+import { MailLinkContext } from "./mail-link-context";
 import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
 import { Button } from "@features/ui";
@@ -19,7 +20,9 @@ const menuItems = [
 export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
+  const openMailLink = useContext(MailLinkContext).openMailLink;
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   return (
     <div
       className={classNames(
@@ -83,7 +86,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() => openMailLink()}
             />
             <MenuItemButton
               text="Collapse"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,14 +6,16 @@ import "@styles/global.scss";
 import type { AppProps } from "next/app";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { NavigationProvider } from "@features/layout";
+import { NavigationProvider, MailLinkProvider } from "@features/layout";
 import { queryClient } from "@api/query-client";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <NavigationProvider>
-        <Component {...pageProps} />
+        <MailLinkProvider>
+          <Component {...pageProps} />
+        </MailLinkProvider>
       </NavigationProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>


### PR DESCRIPTION
This code works, but I'm not sure if it's "too much." I wanted to separate the openMailLink() function from sidebar-navigation.tsx, so I learned how the toggleSidebar() function was implemented via NavigationContext, and generally how React context works. 

It feels a bit overkill for the issue at hand, but it was good to learn about React Context. My first thought was to just make a file consisting only of the openMailLink() function, then I would import it into the component. But it's cool that the code I wrote is reusable, and with some more work, can be made to take in custom parameters for the recipient and subject fields of the draft email.